### PR TITLE
Authentication issues with Mongolab

### DIFF
--- a/src/main/scala/se/radley/plugin/salat/SalatPlugin.scala
+++ b/src/main/scala/se/radley/plugin/salat/SalatPlugin.scala
@@ -21,14 +21,14 @@ class SalatPlugin(app: Application) extends Plugin {
       conn.setWriteConcern(WriteConcern.Safe)
 
       if (user.isDefined && password.isDefined)
-        if (conn.authenticate(user.getOrElse(""), password.getOrElse("")))
+        if (!conn.authenticate(user.getOrElse(""), password.getOrElse("")))
           throw configuration.reportError("mongodb", "Access denied to MongoDB database: [" + db + "] with user: [" + user.getOrElse("") + "]")
       conn(name)
     }
 
     def apply(name: String) = collection(name)
 
-    override def toString() = if(user.isDefined) user.get + "@" else "" + host + ":" + port + "/" + db
+    override def toString() = (if(user.isDefined) user.get + "@" else "") + host + ":" + port + "/" + db
   }
 
   val sources: List[Tuple2[MongoSource, String]] = configuration.subKeys.map { source =>


### PR DESCRIPTION
Hi Leon -

Started using play-salat the other day, but was failing to authenticate with mongolab.com. I dug into the code and found a few issues that are resolved with this commit.

I'm not using authentication with my local mongo instance, but this is definitely an issue with Mongolab.com. Any concerns with these changes?

Thanks,

Dennis

Commit log:

1) MongoSource.toString did not print correct if user was provided. Added parens.
2) Underlying DB.authenticate(String,String) returns true if authenticated; else false. Now handle that correctly -> Was reversed.
