### PR TITLE
Fixed compatibility with play 2.0

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -13,8 +13,8 @@ object ProjectBuild extends Build {
     resolvers += "Typesafe Releases" at "http://repo.typesafe.com/typesafe/releases/",
     resolvers += "Typesafe Snapshots" at "http://repo.typesafe.com/typesafe/snapshots/",
     resolvers += "Novus Snapshots" at "http://repo.novus.com/snapshots/",
-    libraryDependencies += "play" %% "play" % "[2.0,)",
-    libraryDependencies += "play" %% "play-test" % "[2.0,)" % "test",
+    libraryDependencies += "play" %% "play" % "2.0",
+    libraryDependencies += "play" %% "play-test" % "2.0" % "test",
     libraryDependencies += "com.novus" %% "salat-core" % "0.0.8-SNAPSHOT",
 
     publishMavenStyle := true,


### PR DESCRIPTION
When I try to run the sample project, the compilation fails because sbt v0.11.2 uses the latest version of Play available (v2.1).

It seems that when a range version is used, sbt/maven will download the highest version available (see http://docs.codehaus.org/display/MAVEN/Dependency+Mediation+and+Conflict+Resolution).
## 

The compilation error:

> [error] /path/to/play-salat/sample/target/scala-2.9.1/src_managed/main/routes_routing.scala:14: object creation impossible, since:
> [error] method prefix in trait Routes of type => String is not defined
> [error] method setPrefix in trait Routes of type (prefix: String)Unit is not defined
> [error] object Routes extends Router.Routes {
> [error]        ^
> [error] one error found
> [error] {file:/path/to/play-salat/sample/}sample/compile:compile: Compilation failed
