### PR TITLE
Add play classloader to context

### DIFF
--- a/src/main/scala/se/radley/plugin/salat/package.scala
+++ b/src/main/scala/se/radley/plugin/salat/package.scala
@@ -20,6 +20,8 @@ package object salat {
       override val typeHintStrategy = StringTypeHintStrategy(when = TypeHintFrequency.WhenNecessary, typeHint = "_t")
     }
     context.registerGlobalKeyOverride(remapThis = "id", toThisInstead = "_id")
+    context.registerClassLoader(Play.classloader)
+
     context
   }
 


### PR DESCRIPTION
When i developed my computer-database sample I got some feedback on the google groups that you should register the Play classloader with the salat context. See https://groups.google.com/forum/?fromgroups#!starred/play-framework/O27j1q1QuVE for more information.
