### PR TITLE
Release connections when App restarts

### DIFF
--- a/src/main/scala/se/radley/plugin/salat/SalatPlugin.scala
+++ b/src/main/scala/se/radley/plugin/salat/SalatPlugin.scala
@@ -27,7 +27,7 @@ class SalatPlugin(app: Application) extends Plugin {
 
     def collection(name: String) = {
       val conn = connection
-      if (user.isDefined && password.isDefined)
+      if (user.isDefined && password.isDefined && !conn.isAuthenticated)
         if (!conn.authenticate(user.getOrElse(""), password.getOrElse("")))
           throw configuration.reportError("mongodb", "Access denied to MongoDB database: [" + db + "] with user: [" + user.getOrElse("") + "]")
       conn(name)


### PR DESCRIPTION
Fix Issue #15 : Salat doesn't release connections in dev mode when reload
- Keep a reference to each connection initiated by a MongoSource
- Expose a close method on MongoSource allowing to close the underlying connection
- Make the plugin close connections when onStop is called.
