### PR TITLE
Removed SNAPSHOT from casbah-gridfs dependency

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -21,7 +21,7 @@ object ProjectBuild extends Build {
       "play" % "play-exceptions" % "2.1-RC2" % "provided",
       "play" %% "play-test" % "2.1-RC2" % "test",
       "com.novus" %% "salat-core" % "1.9.2-SNAPSHOT",
-      "org.mongodb" %% "casbah-gridfs" % "2.5.0-SNAPSHOT"
+      "org.mongodb" %% "casbah-gridfs" % "2.5.0"
     )
   )
 }


### PR DESCRIPTION
Casbah released version 2.5.0 and salat has already been updated in [Pull Request #73](https://github.com/novus/salat/pull/73).
