### PR TITLE
Update plugin, docs and sample app to Play 2.3.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: scala
 
 scala:
-  - 2.11.1
+  - 2.11.2
   - 2.10.4
 
 branches:

--- a/README.md
+++ b/README.md
@@ -26,11 +26,11 @@ It will ask you a couple of questions, and your ready to rock 'n roll.
 
 ### Manual installation
 Start by adding the plugin, in your `project/Build.scala`
-
-    val appDependencies = Seq(
-      "se.radley" %% "play-plugins-salat" % "1.5.0"
-    )
-
+````scala
+val appDependencies = Seq(
+  "se.radley" %% "play-plugins-salat" % "1.5.0"
+)
+````
 Then we can add the implicit converstions to and from ObjectId by adding to the routesImport and add ObjectId to all the templates
 
 **Play 2.2.x and previous**
@@ -43,7 +43,7 @@ val main = PlayProject(appName, appVersion, appDependencies, mainLang = SCALA).s
 ````
 **Play 2.3.x and subsequent**
 
-````
+````scala
 import play.twirl.sbt.Import.TwirlKeys
 val main = Project(appName, file(".")).enablePlugins(play.PlayScala).settings(
   routesImport += "se.radley.plugin.salat.Binders._",
@@ -124,71 +124,70 @@ Then you can call `mongoCollection("collectionname", "myotherdb")`
 
 ## What a model looks like
 All models must be case classes otherwise salat doesn't know how to properly transform them into MongoDBObject's
+````scala
+package models
 
-    package models
+import play.api.Play.current
+import java.util.Date
+import com.novus.salat._
+import com.novus.salat.annotations._
+import com.novus.salat.dao._
+import com.mongodb.casbah.Imports._
+import se.radley.plugin.salat._
+import mongoContext._
 
-    import play.api.Play.current
-    import java.util.Date
-    import com.novus.salat._
-    import com.novus.salat.annotations._
-    import com.novus.salat.dao._
-    import com.mongodb.casbah.Imports._
-    import se.radley.plugin.salat._
-    import mongoContext._
+case class User(
+  id: ObjectId = new ObjectId,
+  username: String,
+  password: String,
+  address: Option[Address] = None,
+  added: Date = new Date(),
+  updated: Option[Date] = None,
+  deleted: Option[Date] = None,
+  @Key("company_id")company: Option[ObjectId] = None
+)
 
-    case class User(
-      id: ObjectId = new ObjectId,
-      username: String,
-      password: String,
-      address: Option[Address] = None,
-      added: Date = new Date(),
-      updated: Option[Date] = None,
-      deleted: Option[Date] = None,
-      @Key("company_id")company: Option[ObjectId] = None
-    )
+object User extends ModelCompanion[User, ObjectId] {
+  val dao = new SalatDAO[User, ObjectId](collection = mongoCollection("users")) {}
 
-    object User extends ModelCompanion[User, ObjectId] {
-      val dao = new SalatDAO[User, ObjectId](collection = mongoCollection("users")) {}
-
-      def findOneByUsername(username: String): Option[User] = dao.findOne(MongoDBObject("username" -> username))
-      def findByCountry(country: String) = dao.find(MongoDBObject("address.country" -> country))
-    }
-
+  def findOneByUsername(username: String): Option[User] = dao.findOne(MongoDBObject("username" -> username))
+  def findByCountry(country: String) = dao.find(MongoDBObject("address.country" -> country))
+}
+````
 ## Capped Collections
 If you want to use capped collections check this out
+````scala
+package models
 
-    package models
+import play.api.Play.current
+import java.util.Date
+import com.novus.salat._
+import com.novus.salat.annotations._
+import com.novus.salat.dao._
+import com.mongodb.casbah.Imports._
+import se.radley.plugin.salat._
+import mongoContext._
 
-    import play.api.Play.current
-    import java.util.Date
-    import com.novus.salat._
-    import com.novus.salat.annotations._
-    import com.novus.salat.dao._
-    import com.mongodb.casbah.Imports._
-    import se.radley.plugin.salat._
-    import mongoContext._
+case class LogItem(
+  id: ObjectId = new ObjectId,
+  message: String
+)
 
-    case class LogItem(
-      id: ObjectId = new ObjectId,
-      message: String
-    )
-
-    object LogItem extends ModelCompanion[LogItem, ObjectId] {
-      val dao = new SalatDAO[LogItem, ObjectId](collection = mongoCappedCollection("logitems", 1000)) {}
-    }
-
+object LogItem extends ModelCompanion[LogItem, ObjectId] {
+  val dao = new SalatDAO[LogItem, ObjectId](collection = mongoCappedCollection("logitems", 1000)) {}
+}
+````
 ## GridFS
 If you want to store things in gridfs you can do this
+````
+package models
 
-    package models
+import play.api.Play.current
+import se.radley.plugin.salat._
+import mongoContext._
 
-    import play.api.Play.current
-    import se.radley.plugin.salat._
-    import mongoContext._
-
-    val files = gridFS("myfiles")
-
-
+val files = gridFS("myfiles")
+````
 ## Mongo Context
 All models must contain an implicit salat Context. The context is somewhat like a hibernate dialect.
 You can override mapping names and configure how salat does it's type hinting. read more about it [here](https://github.com/novus/salat/wiki/CustomContext)

--- a/README.md
+++ b/README.md
@@ -33,10 +33,23 @@ Start by adding the plugin, in your `project/Build.scala`
 
 Then we can add the implicit converstions to and from ObjectId by adding to the routesImport and add ObjectId to all the templates
 
-    val main = PlayProject(appName, appVersion, appDependencies, mainLang = SCALA).settings(
-      routesImport += "se.radley.plugin.salat.Binders._",
-      templatesImport += "org.bson.types.ObjectId"
-    )
+**Play 2.2.x and previous**
+
+````scala
+val main = PlayProject(appName, appVersion, appDependencies, mainLang = SCALA).settings(
+  routesImport += "se.radley.plugin.salat.Binders._",
+  templatesImport += "org.bson.types.ObjectId"
+)
+````
+**Play 2.3.x and subsequent**
+
+````
+import play.twirl.sbt.Import.TwirlKeys
+val main = Project(appName, file(".")).enablePlugins(play.PlayScala).settings(
+  routesImport += "se.radley.plugin.salat.Binders._",
+  TwirlKeys.templateImports += "org.bson.types.ObjectId"
+)
+````
 
 We now need to register the plugin, this is done by creating(or appending) to the `conf/play.plugins` file
 

--- a/notes/1.5.0.markdown
+++ b/notes/1.5.0.markdown
@@ -1,3 +1,3 @@
 - Salat 1.9.8
-- Play 2.3.1
-- Cross compile against 2.11.1, 2.10.4
+- Play 2.3.2
+- Cross compile against 2.11.2, 2.10.4

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -9,7 +9,7 @@ object ProjectBuild extends Build {
     organization := "se.radley",
     description := "MongoDB Salat plugin for PlayFramework 2",
     version := buildVersion,
-    scalaVersion := "2.11.1",
+    scalaVersion := "2.11.2",
     scalacOptions ++= Seq("-unchecked", "-deprecation", "-feature"),
     crossScalaVersions ++= Seq("2.10.4"),
     parallelExecution in Test := false,
@@ -22,9 +22,9 @@ object ProjectBuild extends Build {
     ),
 
     libraryDependencies ++= Seq(
-      "com.typesafe.play" %% "play" % "2.3.1" % "provided",
-      "com.typesafe.play" % "play-exceptions" % "2.3.1" % "provided",
-      "com.typesafe.play" %% "play-test" % "2.3.1" % "test",
+      "com.typesafe.play" %% "play" % "2.3.2" % "provided",
+      "com.typesafe.play" % "play-exceptions" % "2.3.2" % "provided",
+      "com.typesafe.play" %% "play-test" % "2.3.2" % "test",
       "com.novus" %% "salat" % "1.9.8",
       "org.mongodb" %% "casbah-gridfs" % "2.7.2"
     )

--- a/sample/app/Global.scala
+++ b/sample/app/Global.scala
@@ -12,7 +12,7 @@ object Global extends GlobalSettings {
       User.save(User(
         username = "leon",
         password = "1234",
-        address = Some(Address("Örebro", "123 45", "Sweden"))
+        address = Some(Address("��rebro", "123 45", "Sweden"))
       ))
 
       User.save(User(

--- a/sample/app/views/user.scala.html
+++ b/sample/app/views/user.scala.html
@@ -2,5 +2,5 @@
 
 @main("Hello World!") {
    <h1>Hello my name is @user.username</h1>
-   <p>I was added on the @user.added.format("dd MMM yyyy")</p>
+   <p>I was added on @user.added.format("dd MMM yyyy")</p>
 }

--- a/sample/project/Build.scala
+++ b/sample/project/Build.scala
@@ -1,6 +1,8 @@
 import sbt._
 import Keys._
-import play.Project._
+import play.Play.autoImport._
+import PlayKeys._
+import play.twirl.sbt.Import.TwirlKeys
 
 object ApplicationBuild extends Build {
 
@@ -8,12 +10,15 @@ object ApplicationBuild extends Build {
     val appVersion      = "1.0"
 
     val appDependencies = Seq(
-      "se.radley" %% "play-plugins-salat" % "1.4.0"
+      "com.typesafe.play" %% "play-ws" % "2.3.2",
+      "se.radley" %% "play-plugins-salat" % "1.5.0"
     )
 
-    val main = play.Project(appName, appVersion, appDependencies).settings(
+    val main = Project(appName, file(".")).enablePlugins(play.PlayScala).settings(
+      version :=appVersion,
+      libraryDependencies ++= appDependencies,
       routesImport += "se.radley.plugin.salat.Binders._",
-      templatesImport += "org.bson.types.ObjectId",
+      TwirlKeys.templateImports += "org.bson.types.ObjectId",
       resolvers += Resolver.sonatypeRepo("snapshots")
     )
 

--- a/sample/project/build.properties
+++ b/sample/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.0
+sbt.version=0.13.5

--- a/sample/project/plugins.sbt
+++ b/sample/project/plugins.sbt
@@ -2,11 +2,7 @@
 logLevel := Level.Warn
 
 // The Typesafe repository
-
-resolvers ++= Seq(
-  "Typesafe Releases" at "http://repo.typesafe.com/typesafe/releases/",
-  "Typesafe Snapshots" at "http://repo.typesafe.com/typesafe/snapshots/"
-)
+resolvers += "Typesafe repository" at "http://repo.typesafe.com/typesafe/releases/"
 
 // Use the Play sbt plugin for Play projects
-addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.2.0")
+addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.3.2")


### PR DESCRIPTION
I noticed that a recent update by @edofic bumped the Play version to 2.3.1, but the sample app was still based on 2.2.0, and the README didn't have an example of how to add project settings in Play 2.3.x. (It's changed a bit since 2.2.x.) While I was fixing that, I also updated the Play version to 2.3.2.

If you accept this pull request, could you please push a new version (1.5.0?) to the Sonatype repository? That would be awesome! Thanks so much.
