### PR TITLE
play-salat does not compatible with 2.4

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -24,10 +24,11 @@ object ProjectBuild extends Build {
     libraryDependencies ++= Seq(
       "com.typesafe.play" %% "play" % "2.4.3" % "provided",
       "com.typesafe.play" % "play-exceptions" % "2.4.3" % "provided",
-      "com.typesafe.play" %% "play-test" % "2.4.3" % "test",
+      "com.typesafe.play" %% "play-specs2" % "2.4.3" % "test",
       "com.novus" %% "salat" % "1.9.8",
       "org.mongodb" %% "casbah-gridfs" % "2.7.2"
     )
+    
   )
 }
 

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -3,7 +3,7 @@ import sbt.Keys._
 
 object ProjectBuild extends Build {
 
-  lazy val buildVersion =  "1.5.0"
+  lazy val buildVersion =  "1.5.1"
 
   lazy val root = Project(id = "play-plugins-salat", base = file("."), settings = Project.defaultSettings ++ Publish.settings).settings(
     organization := "se.radley",
@@ -22,9 +22,9 @@ object ProjectBuild extends Build {
     ),
 
     libraryDependencies ++= Seq(
-      "com.typesafe.play" %% "play" % "2.3.1" % "provided",
-      "com.typesafe.play" % "play-exceptions" % "2.3.1" % "provided",
-      "com.typesafe.play" %% "play-test" % "2.3.1" % "test",
+      "com.typesafe.play" %% "play" % "2.4.3" % "provided",
+      "com.typesafe.play" % "play-exceptions" % "2.4.3" % "provided",
+      "com.typesafe.play" %% "play-test" % "2.4.3" % "test",
       "com.novus" %% "salat" % "1.9.8",
       "org.mongodb" %% "casbah-gridfs" % "2.7.2"
     )

--- a/src/main/scala/se/radley/plugin/salat/Binders.scala
+++ b/src/main/scala/se/radley/plugin/salat/Binders.scala
@@ -39,7 +39,7 @@ object Binders {
   /**
    * Convert a ObjectId to a Javascript String
    */
-  implicit def objectIdJavascriptLitteral = new JavascriptLitteral[ObjectId] {
+  implicit def objectIdJavascriptLiteral = new JavascriptLiteral[ObjectId] {
     def to(value: ObjectId) = value.toString
   }
 

--- a/src/main/scala/se/radley/plugin/salat/OptionsFromConfig.scala
+++ b/src/main/scala/se/radley/plugin/salat/OptionsFromConfig.scala
@@ -24,14 +24,12 @@ object OptionsFromConfig {
 
     val builder = new MongoClientOptions.Builder()
 
-    config.getBoolean("autoConnectRetry").map(v => builder.autoConnectRetry(v))
     config.getInt("connectionsPerHost").map(v => builder.connectionsPerHost(v))
     config.getInt("connectTimeout").map(v => builder.connectTimeout(v))
     config.getBoolean("cursorFinalizerEnabled").map(v => builder.cursorFinalizerEnabled(v))
     config.getString("dbDecoderFactory").flatMap(className => getInstanceFromName[DBDecoderFactory](className)).map(v => builder.dbDecoderFactory(v))
     config.getString("dbEncoderFactory").flatMap(className => getInstanceFromName[DBEncoderFactory](className)).map(v => builder.dbEncoderFactory(v))
     config.getString("description").map(v => builder.description(v))
-    config.getLong("maxAutoConnectRetryTime").map(v => builder.maxAutoConnectRetryTime(v))
     config.getInt("maxWaitTime").map(v => builder.maxWaitTime(v))
     config.getString("readPreference").flatMap { name =>
       try {

--- a/src/main/scala/se/radley/plugin/salat/SalatPlugin.scala
+++ b/src/main/scala/se/radley/plugin/salat/SalatPlugin.scala
@@ -8,8 +8,9 @@ import com.mongodb.{MongoClientOptions, MongoException, ServerAddress, MongoOpti
 import com.mongodb.casbah.gridfs.GridFS
 import commons.MongoDBObject
 import com.mongodb.casbah.MongoClientOptions
+import javax.inject.Inject
 
-class SalatPlugin(app: Application) extends Plugin {
+class SalatPlugin @Inject() (implicit app: Application) extends Plugin {
 
   lazy val configuration = app.configuration.getConfig("mongodb").getOrElse(Configuration.empty)
 

--- a/src/test/scala/se/radley/plugin/salat/ObjectIdSpec.scala
+++ b/src/test/scala/se/radley/plugin/salat/ObjectIdSpec.scala
@@ -57,4 +57,5 @@ object ObjectIdSpec extends Specification {
       JsString("not a object id").validate[ObjectId] must equalTo(JsError(Seq(JsPath() -> Seq(ValidationError("validate.error.objectid")))))
     }
   }
+  
 }

--- a/src/test/scala/se/radley/plugin/salat/ObjectIdSpec.scala
+++ b/src/test/scala/se/radley/plugin/salat/ObjectIdSpec.scala
@@ -39,9 +39,9 @@ object ObjectIdSpec extends Specification {
       objectIdPathBindable.unbind("id", id) must equalTo(id.toString)
     }
 
-    "bind to JavascriptLitteral" in {
+    "bind to JavascriptLiteral" in {
       val id = new ObjectId()
-      objectIdJavascriptLitteral.to(id) must equalTo(id.toString)
+      objectIdJavascriptLiteral.to(id) must equalTo(id.toString)
     }
 
     "write to json and read back into ObjectId" in {

--- a/src/test/scala/se/radley/plugin/salat/OptionsFromConfigSpec.scala
+++ b/src/test/scala/se/radley/plugin/salat/OptionsFromConfigSpec.scala
@@ -7,19 +7,18 @@ import javax.net.SocketFactory
 import org.specs2.specification.AllExpectations
 import sun.security.ssl.SSLSocketFactoryImpl
 
+
 class OptionsFromConfigSpec extends Specification with AllExpectations {
 
   "OptionsFromConfig" should {
     "Override all defaults when all props are present" in {
       val allNonDefaultConfiguration = Map(
-        ("mongodb.default.options.autoConnectRetry" -> "true"),
         ("mongodb.default.options.connectionsPerHost" -> "333"),
         ("mongodb.default.options.connectTimeout" -> "34000"),
         ("mongodb.default.options.cursorFinalizerEnabled" -> "true"),
         ("mongodb.default.options.dbDecoderFactory" -> "se.radley.plugin.salat.NonDefaultDBDecoderFactory"),
         ("mongodb.default.options.dbEncoderFactory" -> "se.radley.plugin.salat.NonDefaultDBEncoderFactory"),
         ("mongodb.default.options.description" -> "Some Description"),
-        ("mongodb.default.options.maxAutoConnectRetryTime" -> "20"),
         ("mongodb.default.options.maxWaitTime" -> "68000"),
         ("mongodb.default.options.readPreference" -> "PRIMARY"),
         ("mongodb.default.options.socketFactory" -> "se.radley.plugin.salat.NonDefaultSocketFactory"),
@@ -34,14 +33,12 @@ class OptionsFromConfigSpec extends Specification with AllExpectations {
       optionsOpt must beSome
       val options = optionsOpt.get
       // All Overridden
-      options.isAutoConnectRetry must beTrue
       options.getConnectionsPerHost must be equalTo(333)
       options.getConnectTimeout must be equalTo(34000)
       options.isCursorFinalizerEnabled must beTrue
       options.getDbDecoderFactory must haveClass[NonDefaultDBDecoderFactory]
       options.getDbEncoderFactory must haveClass[NonDefaultDBEncoderFactory]
       options.getDescription must be equalTo("Some Description")
-      options.getMaxAutoConnectRetryTime must be equalTo(20)
       options.getMaxWaitTime must be equalTo(68000)
       options.getReadPreference must be equalTo(ReadPreference.primary())
       options.getSocketFactory must haveClass[NonDefaultSocketFactory]


### PR DESCRIPTION
I have made some changes for play 2.4. But they can not be compiled with old play versions
reason: "objectIdJavascriptLiteral"  misspelling in old versions
